### PR TITLE
Crc leading zero

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -16,7 +16,7 @@ export function crc32(arr: Uint8Array | string): string {
     crc = (crc >>> 8) ^ temp;
   }
 
-  return numberToHex(crc ^ -1);
+  return numberToHex(crc ^ -1).padStart(8, "0");
 }
 
 export class Crc32Stream {

--- a/test.ts
+++ b/test.ts
@@ -11,12 +11,15 @@ import {
 } from "./mod.ts";
 
 const str = "deno";
+const str2 = "33";
 const bytes = new TextEncoder().encode(str);
 const crc32_deno = "fd6f8c63";
+const crc32_33 = "0a6216d9"; // Crc with a leading zero
 
 Deno.test("crc32", () => {
   assertEquals(crc32(str), crc32_deno);
   assertEquals(crc32(bytes), crc32_deno);
+  assertEquals(crc32(str2), crc32_33);
 });
 
 Deno.test("Crc32Stream", () => {


### PR DESCRIPTION
Fix bug where the length of the string returned by the crc32 function is shorter than 8 characters due to a leading zero